### PR TITLE
댓글 엔티티 작성

### DIFF
--- a/board/src/main/java/practice/board/domain/Comment.java
+++ b/board/src/main/java/practice/board/domain/Comment.java
@@ -1,0 +1,72 @@
+package practice.board.domain;
+
+
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Getter
+@ToString
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentId;
+
+    //TODO: 게시글 엔티티로 변경해주기
+    private Long articleId;
+
+    //TODO: 유저 엔티티로 작성시 유저 계정으로 변경
+    private String userId;
+
+    private String content;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @CreatedBy
+    private String createdBy;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    @LastModifiedBy
+    private String modifiedBy;
+
+    protected Comment(){
+
+    }
+
+    private Comment( Long articleId, String userId, String content) {
+        this.articleId = articleId;
+        this.userId = userId;
+        this.content = content;
+    }
+
+    public static Comment of( Long articleId, String userId, String content) {
+        return new Comment(articleId, userId, content);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(commentId);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if( this == obj) return true;
+        if(!(obj instanceof Comment comment)) return false;
+        return commentId != null && commentId.equals(comment.commentId);
+
+    }
+}

--- a/board/src/main/java/practice/board/dto/CommentDto.java
+++ b/board/src/main/java/practice/board/dto/CommentDto.java
@@ -1,0 +1,30 @@
+package practice.board.dto;
+
+import practice.board.domain.Comment;
+
+import java.time.LocalDateTime;
+
+public record CommentDto(
+        Long articleId,
+        String userId, //TODO: 유저 엔티티 작성 시 변경
+        String content,
+        LocalDateTime createdAt,
+        String createdBy,
+        LocalDateTime modifiedAt,
+        String modifiedBy
+) {
+
+    public static CommentDto from(Comment entity) {
+        return new CommentDto(
+                entity.getArticleId(),
+                entity.getUserId(),
+                entity.getContent(),
+                entity.getCreatedAt(),
+                entity.getCreatedBy(),
+                entity.getModifiedAt(),
+                entity.getModifiedBy()
+        );
+    }
+
+
+}

--- a/board/src/test/java/practice/board/domain/CommentTest.java
+++ b/board/src/test/java/practice/board/domain/CommentTest.java
@@ -1,0 +1,33 @@
+package practice.board.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import practice.board.dto.CommentDto;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("Comment 엔티티, Dto 테스트")
+class CommentTest {
+
+    @Test
+    @DisplayName("Comment Entity <-> Dto 변환")
+    void givenNothing_whenChangeDtoFromEntity_thenReturnDto() {
+
+        //Given
+        Long articleId = 1L;
+        String userId = "woojin";
+        String content = "content";
+        Comment comment = Comment.of(articleId, userId, content);
+
+        //When
+        CommentDto commentDto = CommentDto.from(comment);
+
+        //Then
+        assertThat(comment.getContent()).isEqualTo(commentDto.content());
+        //내용 동일한가
+
+
+
+    }
+}


### PR DESCRIPTION
엔티티
1. Getter
2. 댓글 기본 구성
    2.1. 작성자
    2.2. 연관된 게시글 //TODO: OneToOne등 연관매핑 해줘야함
    2.3. 내용
    2.4. 생성자, 생성일

DTO
1. 엔티티를 받아서 DTO로 변환할 수 있게 설계함

Test
1. 엔티티 요소와 DTO 요소를 비교하여 일치하는지 확인함

this is closes #9 