### PR TITLE
연관 맵핑, Dto 수정, 테스트 수정 및 테스트 데이터 추가

### DIFF
--- a/board/src/main/java/practice/board/domain/Article.java
+++ b/board/src/main/java/practice/board/domain/Article.java
@@ -28,13 +28,18 @@ import java.util.*;
 public class Article {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ARTICLE_ID")
     private Long id;
 
     //TODO: 유저 엔티티 작성시 변경
-    private String userAccount;
+    @ManyToOne
+    @JoinColumn(name = "USERACCOUNT_ID")
+    private UserAccount userAccount;
 
     //TODO: 댓글 엔티티 작성시 변경
-    private static Set<String> comments = new LinkedHashSet<>();
+    @OneToMany
+    @JoinColumn(name = "COMMENT_ID")
+    private final Set<Comment> comments = new LinkedHashSet<>();
 
      private String title;
 
@@ -52,9 +57,8 @@ public class Article {
 
 
 
-    private Article(String userAccount, Set<String> comments, String title, String content, String hashtag) {
+    private Article(UserAccount userAccount, String title, String content, String hashtag) {
             this.userAccount = userAccount;
-            Article.comments = comments;
             this.title = title;
             this.content = content;
             this.hashtag = hashtag;
@@ -64,8 +68,8 @@ public class Article {
 
     }
 
-    public static Article of(String userAccount, Set<String> comments, String title, String content, String hashtag) {
-        return new Article(userAccount, comments, title, content, hashtag );
+    public static Article of(UserAccount userAccount, String title, String content, String hashtag) {
+        return new Article(userAccount, title, content, hashtag );
     }
 
 

--- a/board/src/main/java/practice/board/domain/Comment.java
+++ b/board/src/main/java/practice/board/domain/Comment.java
@@ -21,13 +21,18 @@ public class Comment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "COMMENT_ID")
     private Long commentId;
 
     //TODO: 게시글 엔티티로 변경해주기
-    private Long articleId;
+    @ManyToOne
+    @JoinColumn(name = "ARTICLE_ID")
+    private Article articleId;
 
     //TODO: 유저 엔티티로 작성시 유저 계정으로 변경
-    private String userId;
+    @ManyToOne
+    @JoinColumn(name = "USERACCOUNT_ID")
+    private UserAccount userId;
 
     private String content;
 
@@ -47,13 +52,13 @@ public class Comment {
 
     }
 
-    private Comment( Long articleId, String userId, String content) {
+    private Comment( Article articleId, UserAccount userId, String content) {
         this.articleId = articleId;
         this.userId = userId;
         this.content = content;
     }
 
-    public static Comment of( Long articleId, String userId, String content) {
+    public static Comment of( Article articleId, UserAccount userId, String content) {
         return new Comment(articleId, userId, content);
     }
 

--- a/board/src/main/java/practice/board/domain/UserAccount.java
+++ b/board/src/main/java/practice/board/domain/UserAccount.java
@@ -6,9 +6,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.Entity;
-import javax.persistence.EntityListeners;
-import javax.persistence.Id;
+import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.LinkedHashSet;
 import java.util.Objects;
@@ -21,6 +19,7 @@ import java.util.Set;
 public class UserAccount {
 
     @Id
+    @Column(name = "USERACCOUNT_ID")
     private String userId;
 
     private String password;
@@ -34,10 +33,14 @@ public class UserAccount {
     private String address;
 
     //TODO: 게시글 엔티티, 댓글 엔티티 작성 시 변경
+    @OneToMany
+    @JoinColumn(name = "ARTICLE_ID")
 
-    private static Set<String> articles = new LinkedHashSet<>();
+    private final Set<Article> articles = new LinkedHashSet<>();
+    @OneToMany
+    @JoinColumn(name = "COMMENT_ID")
 
-    private static Set<String> comments = new LinkedHashSet<>();
+    private final Set<Comment> comments = new LinkedHashSet<>();
 
     @CreatedDate private LocalDateTime createdAt;
 

--- a/board/src/main/java/practice/board/dto/ArticleDto.java
+++ b/board/src/main/java/practice/board/dto/ArticleDto.java
@@ -3,7 +3,9 @@ package practice.board.dto;
 import practice.board.domain.Article;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public record ArticleDto(
         String title,
@@ -13,7 +15,7 @@ public record ArticleDto(
         String createdBy,
         LocalDateTime modifiedAt,
         String modifiedBy,
-        Set<String> comments
+        Set<CommentDto> comments
 ) {
 
     public static ArticleDto from(Article entity) {
@@ -25,7 +27,9 @@ public record ArticleDto(
                 entity.getCreatedBy(),
                 entity.getModifiedAt(),
                 entity.getModifiedBy(),
-                Set.of()    //TODO: Set<Comment>로 변경
+                entity.getComments().stream()
+                        .map(CommentDto::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new))//TODO: Set<Comment>로 변경
         );
     }
 

--- a/board/src/main/java/practice/board/dto/CommentDto.java
+++ b/board/src/main/java/practice/board/dto/CommentDto.java
@@ -1,12 +1,13 @@
 package practice.board.dto;
 
+import practice.board.domain.Article;
 import practice.board.domain.Comment;
 
 import java.time.LocalDateTime;
 
 public record CommentDto(
-        Long articleId,
-        String userId, //TODO: 유저 엔티티 작성 시 변경
+        ArticleDto articleId,
+        UserAccountDto userId, //TODO: 유저 엔티티 작성 시 변경
         String content,
         LocalDateTime createdAt,
         String createdBy,
@@ -16,8 +17,8 @@ public record CommentDto(
 
     public static CommentDto from(Comment entity) {
         return new CommentDto(
-                entity.getArticleId(),
-                entity.getUserId(),
+                ArticleDto.from(entity.getArticleId()),
+                UserAccountDto.from(entity.getUserId()),
                 entity.getContent(),
                 entity.getCreatedAt(),
                 entity.getCreatedBy(),

--- a/board/src/main/java/practice/board/dto/UserAccountDto.java
+++ b/board/src/main/java/practice/board/dto/UserAccountDto.java
@@ -1,9 +1,12 @@
 package practice.board.dto;
 
+import practice.board.domain.Comment;
 import practice.board.domain.UserAccount;
 
 import java.time.LocalDateTime;
+import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 public record UserAccountDto(
         String userId,
@@ -13,8 +16,8 @@ public record UserAccountDto(
         String phone,
         String address,
         //TODO: 게시글 엔티티, 댓글 엔티티 작성시 변경해야함
-        Set<String> articles,
-        Set<String> comments,
+        Set<ArticleDto> articles,
+        Set<CommentDto> comments,
         LocalDateTime createdAt,
         LocalDateTime modifiedAt
 
@@ -28,8 +31,12 @@ public record UserAccountDto(
                 entity.getNickname(),
                 entity.getPhone(),
                 entity.getAddress(),
-                Set.of(),
-                Set.of(),
+                entity.getArticles().stream()
+                        .map(ArticleDto::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
+                entity.getComments().stream()
+                        .map(CommentDto::from)
+                        .collect(Collectors.toCollection(LinkedHashSet::new)),
                 entity.getCreatedAt(),
                 entity.getModifiedBy()
         );

--- a/board/src/test/java/practice/board/domain/ArticleTest.java
+++ b/board/src/test/java/practice/board/domain/ArticleTest.java
@@ -18,15 +18,34 @@ class ArticleTest {
     void givenNothing_whenCreateArticleEntity_returnArticleEntity() {
 
         //Given
-        Article article = Article.of("woojin", Set.of(), "title", "content",
-                "hashtag");
-        
+        Article article = createArticle();
+
         ArticleDto articleDto = ArticleDto.from(article);
         //When
 
         //Then
         assertThat(articleDto.createdBy()).isEqualTo(article.getCreatedBy());
 
+    }
+
+    protected Article createArticle() {
+        return Article.of(
+            createUser(),
+                "title",
+                "content",
+                "hashtag"
+        );
+    }
+
+    protected UserAccount createUser() {
+        return UserAccount.of(
+                "woojin",
+                "1234",
+                "test@email.com",
+                "woojin",
+                "01012345678",
+                "home"
+        );
     }
 
 }

--- a/board/src/test/java/practice/board/domain/CommentTest.java
+++ b/board/src/test/java/practice/board/domain/CommentTest.java
@@ -15,10 +15,7 @@ class CommentTest {
     void givenNothing_whenChangeDtoFromEntity_thenReturnDto() {
 
         //Given
-        Long articleId = 1L;
-        String userId = "woojin";
-        String content = "content";
-        Comment comment = Comment.of(articleId, userId, content);
+        Comment comment = createCommet();
 
         //When
         CommentDto commentDto = CommentDto.from(comment);
@@ -29,5 +26,34 @@ class CommentTest {
 
 
 
+    }
+
+
+    protected Article createArticle() {
+        return Article.of(
+                createUser(),
+                "title",
+                "content",
+                "hashtag"
+        );
+    }
+
+    protected Comment createCommet() {
+        return Comment.of(
+                createArticle(),
+                createArticle().getUserAccount(),
+                "content"
+        );
+    }
+
+    protected UserAccount createUser() {
+        return UserAccount.of(
+                "woojin",
+                "1234",
+                "test@email.com",
+                "woojin",
+                "01012345678",
+                "home"
+        );
     }
 }

--- a/board/src/test/java/practice/board/domain/UserAccountTest.java
+++ b/board/src/test/java/practice/board/domain/UserAccountTest.java
@@ -16,17 +16,10 @@ class UserAccountTest {
     void givenNothing_whenChangeUserAccountDtoFromDto_thenReturnDto() {
 
         //Given
-        String userId = "woojin";
-        String password= "1234";
-        String email = "test@email.com";
-        String nickname = "woojin";
-        String phone = "01012345678";
-        String address = "seoul";
-        Set<String> articles = Set.of();
-        Set<String> comments = Set.of();
+
 
         //When
-        UserAccount userAccount = UserAccount.of(userId, password, email, nickname, phone, address);
+        UserAccount userAccount = createUser();
         UserAccountDto Dto = UserAccountDto.from(userAccount);
 
         //Then
@@ -36,6 +29,26 @@ class UserAccountTest {
         assertThat(userAccount.getNickname()).isEqualTo(Dto.nickname());
         assertThat(userAccount.getPhone()).isEqualTo(Dto.phone());
         assertThat(userAccount.getAddress()).isEqualTo(Dto.address());
+    }
+
+    protected Article createArticle() {
+        return Article.of(
+                createUser(),
+                "title",
+                "content",
+                "hashtag"
+        );
+    }
+
+    protected UserAccount createUser() {
+        return UserAccount.of(
+                "woojin",
+                "1234",
+                "test@email.com",
+                "woojin",
+                "01012345678",
+                "home"
+        );
     }
 
 }


### PR DESCRIPTION
 * Article 엔티티 연관맵핑 && Dto변경

        Article 엔티티의 요소중에서 Set자료로 댓글들을
        맵핑한 코드가 있다.
        이건 1:N 으로 맵핑했으며
        작성자를 기입하는 코드는
        N:1 로 작성했다.


 * Comment 엔티티, DTO 작성

        Comment 엔티티
        게시글과의 관계는
        N(댓글) : 1(게시글) 관계를 가지고 있어 Many To One의 성질을 가지고 있다.
        
        유저와의 관계는
        N(댓글):1(유저) 관계를 가지고 있어 마찬가지로 ManyTo One
        의 성질을 가지고 있다.
        
        CommentDto에서도 보유하고 있는 객체들이 Dto클래스를 가지고 있어야 하기때문에 Dto로 변환해주었다.
        
        ArticleDto에서는 Set<String> -> Set<Comment>로 수정했으며
        Entity -> DTO로 변환하는 코드에서 comment들을 Dto로 변환했다.


 * UserAccount 엔티티, DTO 매핑, DTO 변경

         UserAccount 엔티티
        유저를 조회했을 때 본인이 쓴 글과 댓글을 확인할 수 있게
        맵핑을 했다.
        1(유저): N(게시글) 의 관계를 가지고 있으며
        1(유저: N(댓글)의 관계를 가지고 있다.
        
        UserAccount DTO 
        게시글들
        Set<String> -> Set<ArticleDto> 로 변경
        댓글들
        Set<String> -> Set(CommentDto>로 변경


테스트

        Entity 연관 맵핑과 Dto에 String이 아닌 Dto클래스를 주입했기 때문에 수정하였다.
        
        테스트의 편의성을 위해 테스트 객체들을 미리 선언하여 필요할 때 불러 사용할 수 있게 했다.

this is closed #13 