### PR TITLE
UserRepository 작성 및 테스트

### DIFF
--- a/board/src/main/java/practice/board/domain/Article.java
+++ b/board/src/main/java/practice/board/domain/Article.java
@@ -31,12 +31,10 @@ public class Article {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //TODO: 유저 엔티티 작성시 변경
     @ManyToOne(cascade = CascadeType.PERSIST)
     @JoinColumn(name = "useraccount_userid")
     private UserAccount userAccount;
 
-    //TODO: 댓글 엔티티 작성시 변경
     //여기서 연관 맵핑할 때 commentId로 해서 제대로 맵핑이 안돼 계속 오류가 발생했다..
     @OneToMany(mappedBy = "articleId", cascade = CascadeType.ALL)
     @ToString.Exclude

--- a/board/src/main/java/practice/board/domain/UserAccount.java
+++ b/board/src/main/java/practice/board/domain/UserAccount.java
@@ -34,12 +34,11 @@ public class UserAccount {
 
     private String address;
 
-    //TODO: 게시글 엔티티, 댓글 엔티티 작성 시 변경
-    @OneToMany(mappedBy = "id", orphanRemoval = true, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "userAccount",  cascade = CascadeType.ALL)
     @ToString.Exclude
     private final Set<Article> articles = new LinkedHashSet<>();
 
-    @OneToMany(mappedBy = "commentId", orphanRemoval = true, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "userId", cascade = CascadeType.ALL)
     @ToString.Exclude
     private final Set<Comment> comments = new LinkedHashSet<>();
 

--- a/board/src/main/java/practice/board/dto/ArticleDto.java
+++ b/board/src/main/java/practice/board/dto/ArticleDto.java
@@ -30,7 +30,7 @@ public record ArticleDto(
                 entity.getModifiedBy(),
                 entity.getComments().stream()
                         .map(CommentDto::from)
-                        .collect(Collectors.toCollection(LinkedHashSet::new))//TODO: Set<Comment>로 변경
+                        .collect(Collectors.toCollection(LinkedHashSet::new))
         );
     }
 

--- a/board/src/main/java/practice/board/dto/CommentDto.java
+++ b/board/src/main/java/practice/board/dto/CommentDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 public record CommentDto(
         ArticleDto articleId,
-        UserAccountDto userId, //TODO: 유저 엔티티 작성 시 변경
+        UserAccountDto userId,
         String content,
         LocalDateTime createdAt,
         String createdBy,

--- a/board/src/main/java/practice/board/dto/UserAccountDto.java
+++ b/board/src/main/java/practice/board/dto/UserAccountDto.java
@@ -14,7 +14,7 @@ public record UserAccountDto(
         String nickname,
         String phone,
         String address,
-        //TODO: 게시글 엔티티, 댓글 엔티티 작성시 변경해야함
+
         Set<ArticleDto> articles,
         Set<CommentDto> comments,
         LocalDateTime createdAt,

--- a/board/src/main/java/practice/board/repository/UserRepository.java
+++ b/board/src/main/java/practice/board/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package practice.board.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import practice.board.domain.UserAccount;
+
+public interface UserRepository extends JpaRepository<UserAccount, Long> {
+
+    public void deleteByUserId(String userId);
+
+}

--- a/board/src/test/java/practice/board/repository/ArticleRepositoryTest.java
+++ b/board/src/test/java/practice/board/repository/ArticleRepositoryTest.java
@@ -5,13 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.AuditorAware;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
-import org.springframework.transaction.annotation.Transactional;
 import practice.board.config.JpaConfig;
 import practice.board.domain.Article;
 import practice.board.domain.Comment;
@@ -24,20 +18,18 @@ import java.util.Set;
 
 import static java.time.LocalTime.now;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.then;
 
 
 @Import(JpaConfig.class)
 @DisplayName("ArticleRepository Test")
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) //실제 디비를 사용하기 위한 설정
-class RepositoryTest {
+class ArticleRepositoryTest {
 
     private final ArticleRepository articleRepository;
 
-    public RepositoryTest(@Autowired ArticleRepository articleRepository) {
+    public ArticleRepositoryTest(@Autowired ArticleRepository articleRepository) {
         this.articleRepository = articleRepository;
     }
 
@@ -91,11 +83,12 @@ class RepositoryTest {
 
         Optional<Article> article = articleRepository.findById(1L);
         Article findArticle = articleRepository.getReferenceById(2L);
-        articleRepository.count();
+        long cmpcount = articleRepository.count();
 
         //Then
         assertThat(article).isEqualTo(Optional.empty());
         assertThat(findArticle.getId()).isEqualTo(2L);
+        assertThat(cmpcount).isEqualTo(count-1L);
     }
 
     protected Article createArticle() {

--- a/board/src/test/java/practice/board/repository/CommentRepositoryTest.java
+++ b/board/src/test/java/practice/board/repository/CommentRepositoryTest.java
@@ -79,6 +79,8 @@ class CommentRepositoryTest {
         //When
         commentRepository.deleteByCommentId(1L);
         long deletedSize = commentRepository.count();
+        //Comment 엔티티에 user와 연관 맵핑하는 곳에서 orphanRemoval = true로 설정하여
+        //자동으로 연관되어있는 객체를 삭제해서 오류가 발생했었다.
 
         //Then
         assertThat(previousecount).isEqualTo(deletedSize+1L);

--- a/board/src/test/java/practice/board/repository/UserRepositoryTest.java
+++ b/board/src/test/java/practice/board/repository/UserRepositoryTest.java
@@ -1,0 +1,118 @@
+package practice.board.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import practice.board.domain.Article;
+import practice.board.domain.Comment;
+import practice.board.domain.UserAccount;
+import practice.board.dto.ArticleDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@DataJpaTest
+@DisplayName("UserRepository - Test")
+class UserRepositoryTest {
+
+    private final UserRepository userRepository;
+
+    public UserRepositoryTest(@Autowired UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @DisplayName("Create UserAccount - Test")
+    @Test
+    void givenNothing_whenCreateUserAccount_thenReturnCreateUserAccount() {
+
+        //Given
+        long previous = userRepository.count();
+        UserAccount user = createUser();
+
+        //When
+        userRepository.save(user);
+        long saveDataSize = userRepository.count();
+
+        //Then
+        assertThat(previous).isEqualTo(saveDataSize-1L);
+    }
+
+    @DisplayName("Delete UserAccount - Test")
+    @Test
+    void givenUserId_whenCreateUserAccount_thenReturnCreateUserAccount() {
+        //TODO: 유저를 삭제할 때 삭제가 되지 않는 현상이 있다. 해결해야 함
+        //Given
+        long saveDataSize = userRepository.count();
+
+
+
+        //When
+
+        long deletedSize = userRepository.count();
+        List<UserAccount> result = userRepository.findAll();
+
+        for(UserAccount user : result) {
+            System.out.println(user);
+            userRepository.deleteByUserId(user.getUserId());
+
+        }
+
+        //Then
+        assertThat(saveDataSize).isEqualTo(userRepository.count());
+    }
+
+
+
+
+    protected ArticleDto createArticleDto() {
+        return new ArticleDto(
+                "dtotitle",
+                "dtocontent",
+                "dtohashtag",
+                LocalDateTime.now(),
+                "woojin",
+                LocalDateTime.now(),
+                "woojin",
+                Set.of()
+        );
+    }
+
+    protected Comment createComment() {
+
+        Article article = createArticle();
+
+        return Comment.of(
+                article,
+                article.getUserAccount(),
+                "content"
+        );
+    }
+
+    protected UserAccount createUser() {
+        return UserAccount.of(
+                "woojin2",
+                "1234",
+                "test@email.com",
+                "woojin2",
+                "01012345678",
+                "home"
+        );
+    }
+    protected Article createArticle() {
+        return Article.of(
+                createUser(),
+                "title",
+                "content",
+                "hashtag"
+        );
+    }
+
+
+}


### PR DESCRIPTION
연관 맵핑을 하면서 TODO 메시지를 제거했다.

UserRepository.java
유저 생성 및 삭제를 구현하려고 했다.
현재 테스트 결과 삭제 기능이 문제가 있다. 삭제를 해도
실제로 삭제가 되지 않는 현상이 있다. 추후에 해결할것이다.

그리고 UserRepository에서 연관 맵핑할 때 조금 수정해 주었다.

TODO: 유저 삭제하는 기능을 구현할 수 있는 방법을 찾아야 함
this is closed #19 