### PR TITLE
Feature/#21 article service

### DIFF
--- a/board/src/main/java/practice/board/domain/Article.java
+++ b/board/src/main/java/practice/board/domain/Article.java
@@ -40,12 +40,12 @@ public class Article {
     @ToString.Exclude
     private final Set<Comment> comments = new LinkedHashSet<>();
 
-     private String title;
+     @Setter private String title;
 
      @Column(length = 3000) @Setter
      private String content;
 
-     private String hashtag;
+     @Setter private String hashtag;
 
      @CreatedDate private LocalDateTime createdAt;
 

--- a/board/src/main/java/practice/board/dto/ArticleDto.java
+++ b/board/src/main/java/practice/board/dto/ArticleDto.java
@@ -9,6 +9,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public record ArticleDto(
+        Long id,
         String title,
         String content,
         String hashtag,
@@ -21,6 +22,7 @@ public record ArticleDto(
 
     public static ArticleDto from(Article entity) {
         return new ArticleDto(
+                entity.getId(),
                 entity.getTitle(),
                 entity.getContent(),
                 entity.getHashtag(),

--- a/board/src/main/java/practice/board/service/ArticleService.java
+++ b/board/src/main/java/practice/board/service/ArticleService.java
@@ -1,0 +1,73 @@
+package practice.board.service;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import practice.board.domain.Article;
+import practice.board.domain.UserAccount;
+import practice.board.dto.ArticleDto;
+import practice.board.repository.ArticleRepository;
+
+import javax.persistence.EntityNotFoundException;
+
+@Slf4j
+@RequiredArgsConstructor  //생성자 관련 어노테이션
+@Service    //Bean
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    public Page<Article> searchArticles() {
+        return Page.empty();
+        //TODO: 검색 기능 추후에 구현 예정
+    }
+
+    public Article getArticle(Long id) {
+        return articleRepository.getReferenceById(id);
+    }
+
+    public ArticleDto getArticleDto(Long id) {
+        return articleRepository.findById(id)
+                .map(ArticleDto::from)
+                .orElseThrow(() -> new EntityNotFoundException("게시글이 없습니다 - articleId: "+ id));
+    }
+
+    public void saveArticle(ArticleDto dto, UserAccount userAccount) {
+        articleRepository.save(dto.toEntity(userAccount));
+    }
+
+    public Article updateArticle(ArticleDto dto, UserAccount userAccount) {
+
+        try{
+            Article updateArticle = articleRepository.getReferenceById(dto.id());
+            if(updateArticle.getUserAccount().equals(userAccount)) {
+                if (dto.title() != null) updateArticle.setTitle(dto.title());
+                if (dto.content() != null) updateArticle.setContent(dto.content());
+                if (dto.content() != null) updateArticle.setHashtag(dto.hashtag());
+            }
+            return updateArticle;
+        }
+        catch(EntityNotFoundException e){
+            log.warn("게시글 업데이트 실패, 게시글을 찾을 수 없습니다. - dto: {}", dto);
+            return null;
+        }
+    }
+
+    public void deleteArticle(Long articleId, UserAccount userAccount) {
+        try {
+            Article findArticle = articleRepository.getReferenceById(articleId);
+            if(findArticle.getUserAccount().equals(userAccount))
+                articleRepository.delete(findArticle);
+        }
+        catch(EntityNotFoundException e) {
+            log.warn("삭제할 게시글이 존재하지 않습니다 - articleId - {}", articleId);
+        }
+
+
+    }
+
+
+}

--- a/board/src/test/java/practice/board/repository/ArticleRepositoryTest.java
+++ b/board/src/test/java/practice/board/repository/ArticleRepositoryTest.java
@@ -47,6 +47,7 @@ class ArticleRepositoryTest {
         long cmpcount = articleRepository.count();
 
         //Then
+        assertThat(article.getId()).isEqualTo(cmp.getId());
         assertThat(article.getClass()).isEqualTo(cmp.getClass());
 
     }
@@ -102,6 +103,7 @@ class ArticleRepositoryTest {
 
     protected ArticleDto createArticleDto() {
         return new ArticleDto(
+                1L,
                 "dtotitle",
                 "dtocontent",
                 "dtohashtag",

--- a/board/src/test/java/practice/board/repository/CommentRepositoryTest.java
+++ b/board/src/test/java/practice/board/repository/CommentRepositoryTest.java
@@ -92,6 +92,7 @@ class CommentRepositoryTest {
 
     protected ArticleDto createArticleDto() {
         return new ArticleDto(
+                1L,
                 "dtotitle",
                 "dtocontent",
                 "dtohashtag",

--- a/board/src/test/java/practice/board/repository/UserRepositoryTest.java
+++ b/board/src/test/java/practice/board/repository/UserRepositoryTest.java
@@ -73,6 +73,7 @@ class UserRepositoryTest {
 
     protected ArticleDto createArticleDto() {
         return new ArticleDto(
+                1L,
                 "dtotitle",
                 "dtocontent",
                 "dtohashtag",

--- a/board/src/test/java/practice/board/service/ArticleServiceTest.java
+++ b/board/src/test/java/practice/board/service/ArticleServiceTest.java
@@ -1,0 +1,205 @@
+package practice.board.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import practice.board.domain.Article;
+import practice.board.domain.Comment;
+import practice.board.domain.UserAccount;
+import practice.board.dto.ArticleDto;
+import practice.board.repository.ArticleRepository;
+import practice.board.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@DisplayName("ArticleService - Test")
+@ExtendWith(MockitoExtension.class)
+class ArticleServiceTest {
+
+    @Mock
+    private ArticleRepository articleRepository;
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private ArticleService articleService;
+
+
+    @DisplayName("SearchArticles - ArticleService")
+    @Test
+    void searchArticles() {
+        //TODO: 검색기능 테스트 아직 구현 안함
+    }
+
+    @DisplayName("GetArticle - ArticleService")
+    @Test
+    void getArticle() {
+
+
+        //Given
+        Article article = createArticle();
+        given(articleRepository.getReferenceById(1L)).willReturn(article);
+
+        //When
+        Article getArticle = articleService.getArticle(1L);
+
+        //Then
+        assertThat(article).isEqualTo(getArticle);
+        then(articleRepository).should().getReferenceById(1L);
+
+    }
+
+    @DisplayName("GetArticleDto - ArticleService")
+    @Test
+    void getArticleDto() {
+
+
+        //Given
+        Article article = createArticle();
+        given(articleRepository.findById(1L)).willReturn(Optional.of(article));
+
+        //When
+        ArticleDto articleDto = articleService.getArticleDto(1L);
+
+        //Then
+        assertThat(articleDto)
+                .hasFieldOrPropertyWithValue("title", article.getTitle())
+                .hasFieldOrPropertyWithValue("content", article.getContent())
+                .hasFieldOrPropertyWithValue("hashtag", article.getHashtag());
+
+        then(articleRepository).should().findById(1L);
+    }
+
+
+    @Test
+    void saveArticle() {
+
+        //Given
+        long count = articleRepository.count();
+        ArticleDto dto = createArticleDto();
+        UserAccount user = createUser();
+        given(articleRepository.save(any(Article.class))).willReturn(createArticle());
+
+        //When
+        articleService.saveArticle(dto, user);
+        long count1 = articleRepository.count();
+
+        //Then
+        assertThat(count).isEqualTo(count1);
+        then(articleRepository).should().save(any(Article.class));
+        System.out.println();
+
+    }
+
+    @Test
+    void updateArticle() {
+        //Given
+        Article createArticle = createArticle();
+        ArticleDto articleDto = updateArticleDto();
+        UserAccount user = createUser();
+        given(articleRepository.getReferenceById(articleDto.id())).willReturn(createArticle);
+        //TODO: article의 ID가 null로 출력되는 현상이 있는데 왜 그런지 궁금함
+
+        //When
+        Article updateArticle = articleService.updateArticle(articleDto, user);
+
+        //Then
+        assertThat(updateArticle.getTitle()).isEqualTo("updatetitle");
+        then(articleRepository).should().getReferenceById(articleDto.id());
+
+    }
+
+    @DisplayName("deleteArticle - ArticleService")
+    @Test
+    void deleteArticle() {
+
+        //Given
+        long articleId = 1L;
+        Article article = createArticle();
+        UserAccount user = createUser();
+        willDoNothing().given(articleRepository).delete(article);
+        given(articleRepository.getReferenceById(articleId)).willReturn(article);
+
+        //When
+        articleService.deleteArticle(articleId, user);
+
+        //Then
+        then(articleRepository).should().delete(article);
+        then(articleRepository).should().getReferenceById(articleId);
+
+    }
+
+
+    protected ArticleDto createArticleDto() {
+        return new ArticleDto(
+                1L,
+                "dtotitle",
+                "dtocontent",
+                "dtohashtag",
+                LocalDateTime.now(),
+                "woojin",
+                LocalDateTime.now(),
+                "woojin",
+                Set.of()
+        );
+    }
+    protected ArticleDto updateArticleDto() {
+        return new ArticleDto(
+                1L,
+                "updatetitle",
+                "updatecontent",
+                "updatehashtag",
+                LocalDateTime.now(),
+                "woojin",
+                LocalDateTime.now(),
+                "woojin",
+                Set.of()
+        );
+    }
+
+    protected Comment createComment() {
+
+        Article article = createArticle();
+
+        Comment comment = Comment.of(
+                article,
+                article.getUserAccount(),
+                "content"
+        );
+        ReflectionTestUtils.setField(comment, "commentId", 1L);
+        return comment;
+
+    }
+
+    protected UserAccount createUser() {
+        return UserAccount.of(
+                "woojin2",
+                "1234",
+                "test@email.com",
+                "woojin2",
+                "01012345678",
+                "home"
+        );
+    }
+    protected Article createArticle() {
+         Article article = Article.of(
+                createUser(),
+                "title",
+                "content",
+                "hashtag"
+        );
+        ReflectionTestUtils.setField(article, "id", 1L);
+         return article;
+    }
+}


### PR DESCRIPTION
ArticleService

        엔티티
        Setter를 'Title', "Content', 'Hashtag' 부분에 추가해주었다.
        게시글을 수정하는데 있어 좀 더 편리하게 setter를 열어주었다.
        
        Dto
        원래 Entity의 Id값을 참조하지 않았지만 유연한 프로그래밍을 위해
        열어주었다.
        
        ArticleService
        1. 게시글 검색기능 미구현
        2. 게시글 찾기 구현
        3. 게시글 찾아서 dto로 반환 구현
        4. 게시글 수정
        5. 게시글 삭제

Service 테스트

      Service로 구현되어있는 함수들을 테스트했으며
      (모두 통과)
      Testcase에서 Dto부분에 Id값을 추가하여 모두 수정해주었다.

TODO: 나중에 Paging 기능을 추가했을 때 검색 및 페이징을 해줘야 한다.
this is closed #21 
