### PR TITLE
검색기능 구현

### DIFF
--- a/board/src/main/java/practice/board/config/JpaConfig.java
+++ b/board/src/main/java/practice/board/config/JpaConfig.java
@@ -18,7 +18,7 @@ public class JpaConfig {
 
     @Bean
     public AuditorAware<String> auditorAware() {
-        return () ->Optional.ofNullable(SecurityContextHolder.getContext())
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
                 .map(SecurityContext::getAuthentication)
                 .filter(Authentication::isAuthenticated)
                 .map(Authentication::getPrincipal)

--- a/board/src/main/java/practice/board/domain/Article.java
+++ b/board/src/main/java/practice/board/domain/Article.java
@@ -18,13 +18,13 @@ import java.util.*;
 @Getter
 @ToString
 @Entity
-@Table( indexes = {
-        @Index(columnList = "title"),
-        @Index(columnList = "content"),
-        @Index(columnList = "hashtag"),
-        @Index(columnList = "createdAt"),
-        @Index(columnList = "createdBy"),
-})
+//@Table( indexes = {
+//        @Index(columnList = "title"),
+//        @Index(columnList = "content"),
+//        @Index(columnList = "hashtag"),
+//        @Index(columnList = "createdAt"),
+//        @Index(columnList = "createdBy"),
+//})
 public class Article extends AuditingFileds {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/board/src/main/java/practice/board/domain/Comment.java
+++ b/board/src/main/java/practice/board/domain/Comment.java
@@ -17,11 +17,6 @@ import java.util.Objects;
 @Getter
 @ToString
 @Entity
-@Table(indexes = {
-        @Index(columnList = "content"),
-        @Index(columnList = "createdAt"),
-        @Index(columnList = "createdBy")
-})
 public class Comment extends AuditingFileds{
 
     @Id

--- a/board/src/main/java/practice/board/domain/UserAccount.java
+++ b/board/src/main/java/practice/board/domain/UserAccount.java
@@ -31,6 +31,7 @@ public class UserAccount extends AuditingFileds{
 
     private String userPassword;
 
+    @Column(unique = true)
     private String email;
 
     private String nickname;

--- a/board/src/main/java/practice/board/repository/ArticleRepository.java
+++ b/board/src/main/java/practice/board/repository/ArticleRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 import practice.board.domain.Article;
 import practice.board.domain.QArticle;
+import practice.board.domain.UserAccount;
 import practice.board.dto.ArticleDto;
 import practice.board.repository.querydsl.ArticleRepositoryCustom;
 
@@ -25,20 +26,21 @@ public interface ArticleRepository extends
     Page<Article> findByHashtag(String hashtag, Pageable pageable);
     Page<Article> findByTitleContaining(String title, Pageable pageable);
     Page<Article> findByContentContaining(String content, Pageable pageable);
-    Page<Article> findByUserAccount_UserIdContaining(String id, Pageable pageable);
-    Page<Article> findByUserAccount_NicknameContaining(String nickname, Pageable pageable);
+    Page<Article> findByUserAccount_UserId(String userId, Pageable pageable);
+    Page<Article> findByCreatedBy(String createdBy, Pageable pageable);
 
 
     public void deleteById(Long id);
     @Override
     default void customize(QuerydslBindings bindings, QArticle root) {
         bindings.excludeUnlistedProperties(true);
-        bindings.including(root.title, root.content, root.hashtag, root.createdAt, root.createdBy);
+        bindings.including(root.title, root.content, root.hashtag, root.createdAt, root.createdBy, root.userAccount);
 //        bindings.bind(root.title).first(StringExpression::likeIgnoreCase);  // like '${v}'  수동으로 넣어주고 싶을 때
         bindings.bind(root.title).first(StringExpression::containsIgnoreCase);  // like '%${v}$%' 자동으로 %를 넣어준다.
         bindings.bind(root.content).first(StringExpression::containsIgnoreCase);
         bindings.bind(root.hashtag).first(StringExpression::containsIgnoreCase);
         bindings.bind(root.createdAt).first(DateTimeExpression::eq);
-        bindings.bind(root.createdBy).first(StringExpression::containsIgnoreCase);
+        bindings.bind(root.createdBy).first(StringExpression::eq);
+//        bindings.bind(root.userAccount).first();
     }
 }

--- a/board/src/main/java/practice/board/repository/UserRepository.java
+++ b/board/src/main/java/practice/board/repository/UserRepository.java
@@ -1,11 +1,37 @@
 package practice.board.repository;
 
+import com.querydsl.core.types.dsl.StringExpression;
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.querydsl.QuerydslPredicateExecutor;
+import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
+import org.springframework.data.querydsl.binding.QuerydslBindings;
+import practice.board.domain.QUserAccount;
 import practice.board.domain.UserAccount;
 
-public interface UserRepository extends JpaRepository<UserAccount, Long> {
+import java.util.List;
+
+public interface UserRepository extends
+        JpaRepository<UserAccount, Long>,
+        QuerydslPredicateExecutor<UserAccount>,
+        QuerydslBinderCustomizer<QUserAccount>
+{
+
 
     UserAccount findByUserId(String UserId);
+    List<UserAccount> findByUserPassword(String password);
+    UserAccount findByEmail(String email);
+
     void deleteByUserId(String userId);
 
+
+
+    @Override
+    default void customize(QuerydslBindings bindings, QUserAccount root) {
+        bindings.excludeUnlistedProperties(true);
+        bindings.including(root.userId, root.userPassword, root.email);
+        bindings.bind(root.userId).first(StringExpression::eq);
+        bindings.bind(root.userPassword).first(StringExpression::eq);
+        bindings.bind(root.email).first(StringExpression::eq);
+    }
 }

--- a/board/src/main/resources/data.sql
+++ b/board/src/main/resources/data.sql
@@ -1,8 +1,8 @@
-insert into practiceboard.user_account (user_id, user_password, nickname, email, created_at, modified_at) values
-    ('uno', 'asdf1234', 'Uno', 'uno@mail.com', now(), now())
+insert into practiceboard.user_account (user_id, user_password, nickname, email, created_at, created_by, modified_at, modified_by) values
+    ('uno', 'asdf1234', 'Uno', 'uno@mail.com', now(), 'uno', now(), 'uno')
 ;
-insert into practiceboard.user_account (user_id, user_password, nickname, email,created_at, modified_at) values
-    ('uno2', 'asdf1234', 'Uno2', 'uno2@mail.com', now(), now())
+insert into practiceboard.user_account (user_id, user_password, nickname, email,created_at, created_by, modified_at, modified_by) values
+    ('uno2', 'asdf1234', 'Uno2', 'uno2@mail.com', now(),'uno2', now(),'uno2')
 ;
 -- 123 게시글
 insert into practiceboard.article (useraccount_userid, title, content, hashtag, created_by, modified_by, created_at, modified_at) values

--- a/board/src/test/java/practice/board/repository/ArticleRepositoryTest.java
+++ b/board/src/test/java/practice/board/repository/ArticleRepositoryTest.java
@@ -51,9 +51,45 @@ class ArticleRepositoryTest {
 
 
         //Then
+        for(Article article: articleDto) {
+            System.out.println("Article: "+ article.getHashtag());
+        }
         assertThat(articleDto.getSize()).isEqualTo(5);
 //        then(articleRepository).should().findByHashtag(color, pageable);
+    }
+    @DisplayName("SearchTitle = Article")
+    @Test
+    void givenSearchTitle_whenSearchArticle_thenReturnArticles() {
 
+
+        //Given
+        String title = "Morbi";
+        Pageable pageable = Pageable.ofSize(10);
+
+        //When
+        Page<Article> findArticles = articleRepository.findByTitleContaining(title, pageable);
+
+        //Then
+        for(Article article: findArticles) {
+            System.out.println("Article: "+article.getContent());
+        }
+
+    }
+
+    @DisplayName("SearchCreatedBy - Article")
+    @Test
+    void givenSearchCreatedBy_whenSearchArticles_thenReturnArticles() {
+        //Given
+        String createdBy = "Arv";
+        Pageable pageable = Pageable.ofSize(10);
+
+        //When
+        Page<Article> findArticles = articleRepository.findByCreatedBy(createdBy, pageable);
+
+        //Then
+        for(Article article: findArticles) {
+            System.out.println("Article: "+article.getCreatedBy());
+        }
     }
 
     @DisplayName("Save Article")

--- a/board/src/test/java/practice/board/repository/UserRepositoryTest.java
+++ b/board/src/test/java/practice/board/repository/UserRepositoryTest.java
@@ -50,9 +50,6 @@ class UserRepositoryTest {
         //TODO: 유저를 삭제할 때 삭제가 되지 않는 현상이 있다. 해결해야 함
         //Given
         long saveDataSize = userRepository.count();
-
-
-
         //When
 
         long deletedSize = userRepository.count();
@@ -67,6 +64,47 @@ class UserRepositoryTest {
         //Then
         assertThat(saveDataSize).isEqualTo(userRepository.count());
     }
+
+    @DisplayName("SearchUserId - UserAccount")
+    @Test
+    void givenUserId_whenfindUser_thenReturnUserAccount() {
+        //Given
+
+        String name = "uno";
+        //When
+        UserAccount user = userRepository.findByUserId(name);
+
+        //Then
+        assertThat(name).isEqualTo(user.getUserId());
+
+    }
+    @DisplayName("CheckPassword - UserAccount")
+    @Test
+    void givenUserPassword_whenCheckUserPassword_thenReturnUserAccount() {
+        //Given
+
+        String password = "asdf1234";
+        //When
+        List<UserAccount> findUsers = userRepository.findByUserPassword(password);
+
+        //Then
+        for(UserAccount user: findUsers) {
+            assertThat(user.getUserPassword()).isEqualTo(password);
+        }
+    }
+    @DisplayName("CheckEmail - UserAccount")
+    @Test
+    void givenUserEmail_whenfindUser_thenReturnUserAccount() {
+        //Given
+
+        String email = "uno@mail.com";
+        //When
+        UserAccount finduser = userRepository.findByEmail(email);
+
+        //Then
+        assertThat(email).isEqualTo(finduser.getEmail());
+    }
+
 
 
 


### PR DESCRIPTION
 * UserAccount

        유저의 이메일을 유일할 수 있게 설정했다.

 * UserRepository

        UserId, 유저 비밀번호, 유저이메일을 확인할 수 있게 작성했다.

 * UserRepositoryTest

        1. 유저 아이디
        2. 유저 비밀번호
        3. 유저 이메일
        확인 가능
      
        정상적으로 동작하는지 테스트 코드를 작성했다.

 * ArticleRepository

      작성자로 검색기능을 추가했다.

 * Article

      Comment Index 네임과 중복되어 둘 다 삭제해주었다.
      좀 더 알아보고 난 후 적용할 것

 * ArticleRepositoryTest

        1. 제목
        2. 내용
        3. 해시태그
        4. 작성자
        를 검색할 수 있는 기능들을 출력하여 해당 내용이 나오는지 테스트했다.

this is closed #27 

